### PR TITLE
added test for failing parse of H2Kd

### DIFF
--- a/mhcnames/__init__.py
+++ b/mhcnames/__init__.py
@@ -7,7 +7,7 @@ from .species import (
 )
 from .allele_parse_error import AlleleParseError
 
-__version__ = "0.3.2"
+__version__ = "0.3.3"
 
 __all__ = [
     "AlleleName",

--- a/mhcnames/allele_name.py
+++ b/mhcnames/allele_name.py
@@ -137,7 +137,6 @@ def parse_allele_name(name, species_prefix=None):
         family = "0" + family
     elif len(family) == 3 and family[0] == "0":
         family = family[1:]
-
     if len(allele_code) == 0:
         allele_code = "01"
     elif len(allele_code) == 1:

--- a/mhcnames/allele_name.py
+++ b/mhcnames/allele_name.py
@@ -66,6 +66,7 @@ def parse_allele_name(name, species_prefix=None):
         raise ValueError("Can't normalize empty MHC allele name")
 
     species_from_name, name = split_species_prefix(name)
+
     if species_prefix:
         if species_from_name:
             raise ValueError("If a species is passed in, we better not have another "

--- a/mhcnames/species.py
+++ b/mhcnames/species.py
@@ -22,7 +22,7 @@ species_name_to_prefixes = dict(
     cattle="BoLA",
     bison="Bibi",
     dog="DLA",
-    sheep=["OVA", "Ovar", "Ovca"],
+    sheep=["Ovar", "OLA", "Ovca"],
     swine="SLA",
     mouse=["H2", "H-2"],
     rainbow_trout="Onmy",
@@ -74,12 +74,21 @@ species_name_to_prefixes = dict(
 
 prefix_to_species_name = {}
 
+_preferred_prefixes = []
+_alternate_prefixes = []
+
 for (species, prefixes) in species_name_to_prefixes.items():
     if isinstance(prefixes, string_types):
         prefixes = [prefixes]
-    for prefix in prefixes:
+    for i, prefix in enumerate(prefixes):
         prefix_to_species_name[prefix] = species
+        if i == 0:
+            _preferred_prefixes.append(prefix)
+        else:
+            _alternate_prefixes.append(prefix)
 
+# list of all species specific prefixes in search order
+_all_prefixes = _preferred_prefixes + _alternate_prefixes
 
 def split_species_prefix(name, seps="-:_ "):
     """
@@ -90,7 +99,7 @@ def split_species_prefix(name, seps="-:_ "):
     species = None
     name_upper = name.upper()
     name_len = len(name)
-    for curr_prefix in prefix_to_species_name.keys():
+    for curr_prefix in _all_prefixes:
         n = len(curr_prefix)
         if name_len <= n:
             continue

--- a/mhcnames/species.py
+++ b/mhcnames/species.py
@@ -81,21 +81,21 @@ for (species, prefixes) in species_name_to_prefixes.items():
         prefix_to_species_name[prefix] = species
 
 
-def split_species_prefix(name):
+def split_species_prefix(name, seps="-:_ "):
     """
     Splits off the species component of the allele name from the rest of it.
 
     Given "HLA-A*02:01", returns ("HLA", "A*02:01").
     """
     species = None
+    name_upper = name.upper()
+    name_len = len(name)
     for curr_prefix in prefix_to_species_name.keys():
         n = len(curr_prefix)
-        if len(name) <= n:
+        if name_len <= n:
             continue
-        if name[n] != "-":
-            continue
-        if name[:n].upper() == curr_prefix.upper():
+        if name_upper.startswith(curr_prefix.upper()):
             species = curr_prefix
-            name = name[n + 1:]
+            name = name[n:].strip(seps)
             break
     return (species, name)

--- a/test/test_mouse_class1.py
+++ b/test/test_mouse_class1.py
@@ -31,3 +31,7 @@ def test_mouse_class1_alleles_H2_Db():
         AlleleName("H-2", "D", "", "b"))
     eq_(normalize_allele_name("H-2-Db"), "H-2-Db")
     eq_(compact_allele_name("H-2-Db"), "Db")
+
+def test_H2_Kd_without_seps():
+    eq_(parse_allele_name("H2Kd"),
+        AlleleName("H-2", "K", "", "d"))


### PR DESCRIPTION
Fixes https://github.com/hammerlab/mhcnames/issues/2

Problem:
```
In [1]: mhcnames.normalize_allele_name("H2Kd")
Out[1]: 'HLA-H*02:01'
```

The reason we get this crazy parse is that the helper `split_species_prefix` expects the species part of an MHC name to be separated by a dash and thus misses "H2", interpreting instead as part of the allele name for a human allele. The new implementation allows for multiple separators (not necessarily a dash) but also allows for there to be no separator if a string starts with a species prefix. 

I'm not sure how "H2Kd" then ends up being interpreted as "H0201" but I also don't want to spent too much time on this parsing code to find out. I have a replacement in mind that uses explicitly enumerated species to guide the parsing, which makes it easier to catch exceptional circumstances. 
