### PR TITLE
Fix omit_dra1 caching

### DIFF
--- a/mhcnames/__init__.py
+++ b/mhcnames/__init__.py
@@ -7,7 +7,7 @@ from .species import (
 )
 from .allele_parse_error import AlleleParseError
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 
 __all__ = [
     "AlleleName",

--- a/mhcnames/normalization.py
+++ b/mhcnames/normalization.py
@@ -18,6 +18,8 @@ from .allele_name import AlleleName
 from .class2 import parse_classi_or_classii_allele_name
 
 _normalized_allele_cache = {}
+for omit_dra1 in [True, False]:
+    _normalized_allele_cache[omit_dra1] = {}
 
 _DRA1_0101 = AlleleName(
     species="HLA",
@@ -65,8 +67,8 @@ def normalize_allele_name(raw_allele, omit_dra1=False):
     These should all be normalized to:
         HLA-A*02:01
     """
-    if raw_allele in _normalized_allele_cache:
-        return _normalized_allele_cache[raw_allele]
+    if raw_allele in _normalized_allele_cache[omit_dra1]:
+        return _normalized_allele_cache[omit_dra1][raw_allele]
     parsed_alleles = parse_classi_or_classii_allele_name(raw_allele)
     species = parsed_alleles[0].species
     normalized_list = [species]
@@ -93,7 +95,7 @@ def normalize_allele_name(raw_allele, omit_dra1=False):
                 parsed_allele.gene,
                 parsed_allele.allele_code))
     normalized = "-".join(normalized_list)
-    _normalized_allele_cache[raw_allele] = normalized
+    _normalized_allele_cache[omit_dra1][raw_allele] = normalized
     return normalized
 
 def compact_allele_name(raw_allele):


### PR DESCRIPTION
Fixing a bug in https://github.com/hammerlab/mhcnames/pull/15 that caused strange errors because `_normalized_allele_cache` was storing both `omit_dra1` `True` and `False` alleles. So after running an IEDB predictor, running a non-IEDB predictor threw up.