### PR TITLE
Raise an exception when there's extra text at the end of an allele name

### DIFF
--- a/mhcnames/__init__.py
+++ b/mhcnames/__init__.py
@@ -7,7 +7,7 @@ from .species import (
 )
 from .allele_parse_error import AlleleParseError
 
-__version__ = "0.3.3"
+__version__ = "0.3.4"
 
 __all__ = [
     "AlleleName",

--- a/mhcnames/allele_name.py
+++ b/mhcnames/allele_name.py
@@ -131,7 +131,13 @@ def parse_allele_name(name, species_prefix=None):
 
     sep, name = parse_separator(name)
 
-    allele_code, name = parse_numbers(name)
+    allele_code, rest_of_text = parse_numbers(name)
+
+    rest_of_text = rest_of_text.strip()
+    if len(rest_of_text) > 0:
+        raise AlleleParseError("The suffix '%s' of '%s' was not parsed" % (
+            original,
+            rest_of_text))
 
     if len(family) == 1:
         family = "0" + family

--- a/test/test_bad_inputs.py
+++ b/test/test_bad_inputs.py
@@ -1,0 +1,6 @@
+from nose.tools import raises
+from mhcnames import normalize_allele_name, AlleleParseError
+
+@raises(AlleleParseError)
+def test_extra_text_after_allele():
+    normalize_allele_name("HLA-A*02:01 zipper")


### PR DESCRIPTION
mhcnames seems to currently silently parse "HLA-A\*02:01 C30S mutant" as just "HLA-A\*02:01" (see https://github.com/hammerlab/mhcnames/issues/20). This branch makes it so any extra text at the end causes an `AlleleParseError` exception to be raised.

Future plan: support parsing of mutations at the end of an allele (related: https://github.com/hammerlab/mhcnames/issues/19) 