### PR TITLE
Made inference of alpha chain for class 2 alleles more explicit

### DIFF
--- a/mhcnames/__init__.py
+++ b/mhcnames/__init__.py
@@ -7,7 +7,7 @@ from .species import (
 )
 from .allele_parse_error import AlleleParseError
 
-__version__ = "0.3.11"
+__version__ = "0.4.0"
 
 __all__ = [
     "AlleleName",

--- a/test/test_human_class2.py
+++ b/test/test_human_class2.py
@@ -30,3 +30,18 @@ def test_human_class2_alpha_beta():
                  "DPA10105/DPB110001"]:
         eq_(normalize_allele_name(name), expected)
         eq_(compact_allele_name(name), expected_compact)
+
+def test_alpha_chain_inference_DP():
+    # example of common DP haplotype from wikipedia article on HLA-DP
+    just_beta = "HLA-DPB1*04:01"
+    expected = "HLA-DPA1*01:03-DPB1*04:01"
+    eq_(normalize_allele_name(just_beta, infer_class2_pair=True), expected)
+    eq_(normalize_allele_name(just_beta, infer_class2_pair=False), just_beta)
+
+def test_alpha_chain_inference_DQ():
+    # example of common DQ haplotype from wikipedia article on HLA-DQ
+    just_beta = "HLA-DQB1*06:02"
+    expected = "HLA-DQA1*01:02-DQB1*06:02"
+    eq_(normalize_allele_name(just_beta, infer_class2_pair=True), expected)
+    eq_(normalize_allele_name(just_beta, infer_class2_pair=False), just_beta)
+


### PR DESCRIPTION
Problem: Sometimes class II alleles in IEDB are listed using only the beta chain (or more rarely, just the alpha chain). This is fine for DRB since almost everyone on the planet has the same alpha allele (DRA1-01:01). However, for DP and DQ alleles, the implicit other chain is omitted by convention when there is some very common other allele. I don't know how to determine these pairing except by including tables of population frequency in mhcnames, but to get started: I made this extra inference step optional and added defaults for genes other than DR. 