### PR TITLE
Add deprecation notice: use mhcgnomes instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+> **⚠️ DEPRECATED:** mhcnames is no longer maintained. Please use [mhcgnomes](https://github.com/openvax/mhcgnomes) instead, which provides a superset of mhcnames functionality with support for more MHC nomenclature systems.
+
+---
+
 # **DEPRECATED: you should use [mhcgnomes](https://pypi.org/project/mhcgnomes/) instead**
 
 <a href="https://travis-ci.org/openvax/mhcnames">


### PR DESCRIPTION
## Summary
Add deprecation notice to README directing users to mhcgnomes.

mhctools 2.x has migrated from mhcnames to mhcgnomes. No openvax packages depend on mhcnames anymore.